### PR TITLE
Add new GitGutter scopes

### DIFF
--- a/Monokai Extended Bright.JSON-tmTheme
+++ b/Monokai Extended Bright.JSON-tmTheme
@@ -512,6 +512,20 @@
             }
         },
         {
+            "name": "GitGutter ignored",
+            "scope": "markup.ignored.git_gutter",
+            "settings": {
+                "foreground": "#565656"
+            }
+        },
+        {
+            "name": "GitGutter untracked",
+            "scope": "markup.untracked.git_gutter",
+            "settings": {
+                "foreground": "#565656"
+            }
+        },
+        {
             "scope": "constant.numeric.line-number.find-in-files - match", 
             "settings": {
                 "foreground": "#AE81FFA0"

--- a/Monokai Extended Bright.tmTheme
+++ b/Monokai Extended Bright.tmTheme
@@ -839,6 +839,28 @@
 		    <string>#967EFB</string>
 		  </dict>
 		</dict>
+		<dict>
+		  <key>name</key>
+		  <string>GitGutter ignored</string>
+		  <key>scope</key>
+		  <string>markup.ignored.git_gutter</string>
+		  <key>settings</key>
+		  <dict>
+		    <key>foreground</key>
+		    <string>#565656</string>
+		  </dict>
+		</dict>
+		<dict>
+		  <key>name</key>
+		  <string>GitGutter untracked</string>
+		  <key>scope</key>
+		  <string>markup.untracked.git_gutter</string>
+		  <key>settings</key>
+		  <dict>
+		    <key>foreground</key>
+		    <string>#565656</string>
+		  </dict>
+		</dict>
 <!--/X-->
 		<dict>
 			<key>scope</key>

--- a/Monokai Extended.JSON-tmTheme
+++ b/Monokai Extended.JSON-tmTheme
@@ -1046,7 +1046,21 @@
             "settings": {
                 "foreground": "#967EFB"
             }
-        }
+        },
+        {
+            "name": "GitGutter ignored",
+            "scope": "markup.ignored.git_gutter",
+            "settings": {
+                "foreground": "#565656"
+            }
+        },
+        {
+            "name": "GitGutter untracked",
+            "scope": "markup.untracked.git_gutter",
+            "settings": {
+                "foreground": "#565656"
+            }
+        },
     ], 
     "uuid": "1D07ACC0-832F-11E2-9E96-0800200C9A66"
 }

--- a/Monokai Extended.tmTheme
+++ b/Monokai Extended.tmTheme
@@ -1686,6 +1686,28 @@
 				<string>#967EFB</string>
 			</dict>
 		</dict>
+		<dict>
+			<key>name</key>
+			<string>GitGutter ignored</string>
+			<key>scope</key>
+			<string>markup.ignored.git_gutter</string>
+			<key>settings</key>
+			<dict>
+			    <key>foreground</key>
+			    <string>#565656</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>GitGutter untracked</string>
+			<key>scope</key>
+			<string>markup.untracked.git_gutter</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#565656</string>
+			</dict>
+		</dict>
 	</array>
 	<key>uuid</key>
 	<string>1D07ACC0-832F-11E2-9E96-0800200C9A66</string>


### PR DESCRIPTION
I have a new feature in GitGutter to show [icons for untracked files](https://github.com/jisaacks/GitGutter#untracked-files). This pull request would add color defs for the new icons.
