### PR TITLE
Made the SublimeLinter note text readable.

### DIFF
--- a/Monokai Extended Bright.tmTheme
+++ b/Monokai Extended Bright.tmTheme
@@ -872,7 +872,7 @@
 				<key>background</key>
 				<string>#FFFFAA</string>
 				<key>foreground</key>
-				<string>#FFFFFF</string>
+				<string>#333333</string>
 			</dict>
 		</dict>
 		<dict>

--- a/Monokai Extended.tmTheme
+++ b/Monokai Extended.tmTheme
@@ -1720,7 +1720,7 @@
 				<key>background</key>
 				<string>#FFFFAA</string>
 				<key>foreground</key>
-				<string>#FFFFFF</string>
+				<string>#333333</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
White on light yellow made the text in ``//TODO` completely unreadable.  Minor, but annoying.
