### PR TITLE
Add syntax highlighting for Embedded code

### DIFF
--- a/Monokai Extended Bright.tmTheme
+++ b/Monokai Extended Bright.tmTheme
@@ -323,6 +323,17 @@
 		</dict>
 		<dict>
 			<key>name</key>
+			<string>Embedded Source</string>
+			<key>scope</key>
+			<string>text source</string>
+			<key>settings</key>
+			<dict>
+				<key>background</key>
+				<string>#2F312A</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
 			<string>String variable</string>
 			<key>scope</key>
 			<string>string variable</string>

--- a/Monokai Extended.tmTheme
+++ b/Monokai Extended.tmTheme
@@ -323,7 +323,7 @@
 			<key>settings</key>
 			<dict>
 				<key>background</key>
-				<string>#303030</string>
+				<string>#292929</string>
 			</dict>
 		</dict>
 		<dict>

--- a/Monokai Extended.tmTheme
+++ b/Monokai Extended.tmTheme
@@ -312,7 +312,18 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#f6aa11</string>
+				<string>#303030</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Embedded Source</string>
+			<key>scope</key>
+			<string>text source</string>
+			<key>settings</key>
+			<dict>
+				<key>background</key>
+				<string>#2F312A</string>
 			</dict>
 		</dict>
 		<dict>

--- a/Monokai Extended.tmTheme
+++ b/Monokai Extended.tmTheme
@@ -312,7 +312,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#303030</string>
+				<string>>#f6aa11</string>
 			</dict>
 		</dict>
 		<dict>
@@ -323,7 +323,7 @@
 			<key>settings</key>
 			<dict>
 				<key>background</key>
-				<string>#2F312A</string>
+				<string>#303030</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Add syntax highlighting for php, js, css embedded

before:
![1](https://f.cloud.github.com/assets/1000317/1843657/5d445e9e-74da-11e3-9177-f083fd360c57.png)

after:
![2](https://f.cloud.github.com/assets/1000317/1843658/623f534a-74da-11e3-933d-e3195c30d48c.png)
