### PR TITLE
adds support for #id in scss

### DIFF
--- a/Monokai Extended.tmTheme
+++ b/Monokai Extended.tmTheme
@@ -479,6 +479,17 @@
 		</dict>
 		<dict>
 			<key>name</key>
+			<string>CSS: #Id for SCSS</string>
+			<key>scope</key>
+			<string>meta.selector.css entity.other.attribute-name.id</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f6aa11</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
 			<string>CSS: .class</string>
 			<key>scope</key>
 			<string>meta.selector.css entity.other.attribute-name.class</string>


### PR DESCRIPTION
references #9 

![monokai-scss-before-after](https://cloud.githubusercontent.com/assets/205659/2795070/fa8dc4a8-cbf4-11e3-92bf-8c96f1bbf0bd.png)

> the color of the comments in `css` and `scss` was different before this change
