### PR TITLE
optimize

### DIFF
--- a/Monokai Extended.tmTheme
+++ b/Monokai Extended.tmTheme
@@ -481,7 +481,7 @@
 			<key>name</key>
 			<string>CSS: #Id for SCSS</string>
 			<key>scope</key>
-			<string>meta.selector.css entity.other.attribute-name.id</string>
+			<string>entity.other.attribute-name.id</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>


### PR DESCRIPTION
references #30 

this is awkward but I've just realized that `meta.selector.css` is not actually needed. Thanks for :shipit: the PR so fast!
