### PR TITLE
Remove italic style from HTML script tags

### DIFF
--- a/Monokai Extended Light.tmTheme
+++ b/Monokai Extended Light.tmTheme
@@ -382,7 +382,7 @@
 			<key>settings</key>
 			<dict>
 				<key>fontStyle</key>
-				<string>italic</string>
+				<string></string>
 			</dict>
 		</dict>
 		<dict>

--- a/Monokai Extended.JSON-tmTheme
+++ b/Monokai Extended.JSON-tmTheme
@@ -229,7 +229,7 @@
             "name": "HTML: Script", 
             "scope": "entity.name.tag.script.html", 
             "settings": {
-                "fontStyle": "italic"
+                "fontStyle": ""
             }
         }, 
         {

--- a/Monokai Extended.tmTheme
+++ b/Monokai Extended.tmTheme
@@ -382,7 +382,7 @@
 			<key>settings</key>
 			<dict>
 				<key>fontStyle</key>
-				<string>italic</string>
+				<string></string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Remove italic style from script tags in Extended and Extended Light to match original Monokai theme and resolve #39.

I'm not familiar with editing ST themes but these changes seems to do the job. The containing `<dict>` tag now seems to be redundant and I noticed that the same result can be achieved by removing it entirely. I didn't go quite that far though as I wasn't sure if it would have a knock-on effect elsewhere.