### PR TITLE
Fix #13 PHPDoc Highlighting

### DIFF
--- a/Monokai Extended Light.tmTheme
+++ b/Monokai Extended Light.tmTheme
@@ -886,19 +886,6 @@
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>PHP: Comment</string>
-			<key>scope</key>
-			<string>keyword.other.phpdoc</string>
-			<key>settings</key>
-			<dict>
-				<key>fontStyle</key>
-				<string></string>
-				<key>foreground</key>
-				<string>#7c7865</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>name</key>
 			<string>PHP: Source Emebedded</string>
 			<key>scope</key>
 			<string>source.php.embedded.block.html</string>

--- a/Monokai Extended.tmTheme
+++ b/Monokai Extended.tmTheme
@@ -886,19 +886,6 @@
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>PHP: Comment</string>
-			<key>scope</key>
-			<string>keyword.other.phpdoc</string>
-			<key>settings</key>
-			<dict>
-				<key>fontStyle</key>
-				<string></string>
-				<key>foreground</key>
-				<string>#7c7865</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>name</key>
 			<string>PHP: Source Emebedded</string>
 			<key>scope</key>
 			<string>source.php.embedded.block.html</string>


### PR DESCRIPTION
> When selecting Monokai Extended as the Color Scheme the symbol
highlighting for phpDoc no longer works. Selection the core Monokai
scheme works fine.

Before

![issue-13-before](https://cloud.githubusercontent.com/assets/44148/6886439/aede530e-d636-11e4-9311-4f222ec10f27.png)

After

![issue-13-after](https://cloud.githubusercontent.com/assets/44148/6886438/aed95476-d636-11e4-8879-18075cbef639.png)