### PR TITLE
'GitGutter changed' color changed from #967EFB to #DDB700

### DIFF
--- a/Monokai Extended.JSON-tmTheme
+++ b/Monokai Extended.JSON-tmTheme
@@ -1044,7 +1044,7 @@
             "name": "GitGutter changed", 
             "scope": "markup.changed.git_gutter", 
             "settings": {
-                "foreground": "#967EFB"
+                "foreground": "#DDB700"
             }
         },
         {

--- a/Monokai Extended.tmTheme
+++ b/Monokai Extended.tmTheme
@@ -1683,7 +1683,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#967EFB</string>
+				<string>#DDB700</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Hello!
I believe it could be quite natural to change the `GitGutter changed` colour from light purple (`#967EFB`) to deep yellow (`#DDB700`).
It will help to achieve the natural '_traffic light_' visual effect, if you like. Its colour meaning is easy to most of us. In terms of manipulating data green means '_to add_', yellow means '_to modify/change_', red means '_to delete_'. I think it would make managing plain text modifications with the help of GitGutter visually easier.
Hope it will make sense & thanks for your project!
