### PR TITLE
JS literal language variables support when using babel-sublime

### DIFF
--- a/Monokai Extended.JSON-tmTheme
+++ b/Monokai Extended.JSON-tmTheme
@@ -402,6 +402,14 @@
             "settings": {
                 "foreground": "#ae81ff"
             }
+        },
+        {
+            "JS: Literal language variable":
+            "scope": "variable.language.arguments.js, variable.language.super.js, variable.language.this.js, variable.language.self.js, variable.language.proto.js, variable.language.constructor.js, variable.language.prototype.js",
+            "settings": {
+                "fontStyle": " italic", 
+                "foreground": "#66d9ef"
+            }
         }, 
         {
             "name": "JS: []", 

--- a/Monokai Extended.tmTheme
+++ b/Monokai Extended.tmTheme
@@ -671,6 +671,19 @@
 		</dict>
 		<dict>
 			<key>name</key>
+			<string>JS: Literal language variable</string>
+			<key>scope</key>
+			<string>variable.language.arguments.js, variable.language.super.js, variable.language.this.js, variable.language.self.js, variable.language.proto.js, variable.language.constructor.js, variable.language.prototype.js</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string> italic</string>
+				<key>foreground</key>
+				<string>#66d9ef</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
 			<string>JS: []</string>
 			<key>scope</key>
 			<string>meta.brace.square.js</string>

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Adds scopes, support and/or improves styling for:
 * `js: source`
 * `js: function`
 * `js: numeric constant`
+* `js: literal language variable` (When using [babel-sublime](https://github.com/babel/babel-sublime))
 * `js: []`
 * `js: ()`
 * `js: {}`


### PR DESCRIPTION
Highlighting for `this`, `.prototype` etc. when using [babel-sublime](https://github.com/babel/babel-sublime) Javascript syntax definition