### PR TITLE
Fixed incorrect color use on python class and function keywords

### DIFF
--- a/Monokai Extended Origin.JSON-tmTheme
+++ b/Monokai Extended Origin.JSON-tmTheme
@@ -616,7 +616,7 @@
             "scope": "storage.type.class.python, storage.type.function.python, storage.modifier.global.python",
             "settings": {
                 "fontStyle": "",
-                "foreground": "#a6e22e"
+                "foreground": "#3bc0f0"
             }
         },
         {

--- a/Monokai Extended Origin.tmTheme
+++ b/Monokai Extended Origin.tmTheme
@@ -998,7 +998,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#a6e22e</string>
+				<string>#3bc0f0</string>
 			</dict>
 		</dict>
 		<dict>

--- a/Monokai Extended.JSON-tmTheme
+++ b/Monokai Extended.JSON-tmTheme
@@ -619,7 +619,7 @@
             "scope": "storage.type.class.python, storage.type.function.python, storage.modifier.global.python", 
             "settings": {
                 "fontStyle": "", 
-                "foreground": "#a6e22e"
+                "foreground": "#3bc0f0"
             }
         }, 
         {

--- a/Monokai Extended.tmTheme
+++ b/Monokai Extended.tmTheme
@@ -1001,7 +1001,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#a6e22e</string>
+				<string>#3bc0f0</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
This change make the python class/def words highlight in blue and not green. Makes the syntax more consistent with the other variants in this repo