### PR TITLE
Fixed diff syntax highlighting in 'Bright' theme

### DIFF
--- a/Monokai Extended Bright.JSON-tmTheme
+++ b/Monokai Extended Bright.JSON-tmTheme
@@ -340,21 +340,21 @@
         }, 
         {
             "name": "diff.deleted", 
-            "scope": "Markdown.deleted", 
+            "scope": "markup.deleted", 
             "settings": {
                 "foreground": "#F92672"
             }
         }, 
         {
             "name": "diff.inserted", 
-            "scope": "Markdown.inserted", 
+            "scope": "markup.inserted", 
             "settings": {
                 "foreground": "#A6E22E"
             }
         }, 
         {
             "name": "diff.changed", 
-            "scope": "Markdown.changed", 
+            "scope": "markup.changed", 
             "settings": {
                 "foreground": "#E6DB74"
             }

--- a/Monokai Extended Bright.tmTheme
+++ b/Monokai Extended Bright.tmTheme
@@ -553,7 +553,7 @@
 			<key>name</key>
 			<string>diff.deleted</string>
 			<key>scope</key>
-			<string>Markdown.deleted</string>
+			<string>markup.deleted</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
@@ -564,7 +564,7 @@
 			<key>name</key>
 			<string>diff.inserted</string>
 			<key>scope</key>
-			<string>Markdown.inserted</string>
+			<string>markup.inserted</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
@@ -575,7 +575,7 @@
 			<key>name</key>
 			<string>diff.changed</string>
 			<key>scope</key>
-			<string>Markdown.changed</string>
+			<string>markup.changed</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>


### PR DESCRIPTION
Late changes broke syntax highlighting for diffs in Bright theme. Seems like mistake, corrected.