### PR TITLE
Improvement for new LaTeX Syntax

### DIFF
--- a/Monokai Extended Bright.tmTheme
+++ b/Monokai Extended Bright.tmTheme
@@ -899,6 +899,17 @@
 		</dict>
 		<dict>
 			<key>name</key>
+			<string>LaTeX: Math Variables</string>
+			<key>scope</key>
+			<string>variable.other.math.tex</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#E6DB74</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
 			<string>GitGutter deleted</string>
 			<key>scope</key>
 			<string>markup.deleted.git_gutter</string>

--- a/Monokai Extended Light.tmTheme
+++ b/Monokai Extended Light.tmTheme
@@ -1566,6 +1566,17 @@
 		</dict>
 		<dict>
 			<key>name</key>
+			<string>LaTeX: Math Variables</string>
+			<key>scope</key>
+			<string>variable.other.math.tex</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#998f2f</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
 			<string>Other: Removal</string>
 			<key>scope</key>
 			<string>other.package.exclude, other.remove</string>

--- a/Monokai Extended Origin.tmTheme
+++ b/Monokai Extended Origin.tmTheme
@@ -1837,6 +1837,17 @@
 		</dict>
 		<dict>
 			<key>name</key>
+			<string>LaTeX: Math Variables</string>
+			<key>scope</key>
+			<string>variable.other.math.tex</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#E6DB74</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
 			<string>GitGutter deleted</string>
 			<key>scope</key>
 			<string>markup.deleted.git_gutter</string>

--- a/Monokai Extended.tmTheme
+++ b/Monokai Extended.tmTheme
@@ -1605,6 +1605,17 @@
     </dict>
     <dict>
       <key>name</key>
+      <string>LaTeX: Math Variables</string>
+      <key>scope</key>
+      <string>variable.other.math.tex</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#e6db74</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
       <string>Other: Removal</string>
       <key>scope</key>
       <string>other.package.exclude, other.remove</string>


### PR DESCRIPTION
The rewrite of the LaTeX Syntax https://github.com/sublimehq/Packages/pull/370 changes the scope for math from string to a meta scope. This PR changes the highlighting, such that the special math highlighting will persist (even improved).

| Color Scheme | before | after | after + this PR |
| --- | --- | --- | --- |
| normal | ![me_s0_c0](https://cloud.githubusercontent.com/assets/12573621/16907508/864df7a4-4cc4-11e6-8323-9cc70da4f081.png) | ![me_s1_c0](https://cloud.githubusercontent.com/assets/12573621/16907513/8cc5e81c-4cc4-11e6-91d9-28c5fad3e2f1.png) | ![me_s1_c1](https://cloud.githubusercontent.com/assets/12573621/16907517/92646906-4cc4-11e6-8f59-63781e1ae9a7.png) |
| Origin | ![me__orig_s0_c0](https://cloud.githubusercontent.com/assets/12573621/16907530/a9ea77a0-4cc4-11e6-9429-de5d1e4b0f61.png) | ![me__orig_s1_c0](https://cloud.githubusercontent.com/assets/12573621/16907538/b0ac9fd2-4cc4-11e6-9c77-979a2bb9d0db.png) | ![me__orig_s1_c1](https://cloud.githubusercontent.com/assets/12573621/16907541/b51f1784-4cc4-11e6-9e13-6b71a4f44bd2.png) |
| Bright | ![me__bright_s0_c0](https://cloud.githubusercontent.com/assets/12573621/16907553/d36d1038-4cc4-11e6-8ba7-71cbb31a5fea.png) | ![me__bright_s1_c0](https://cloud.githubusercontent.com/assets/12573621/16907558/db44e48e-4cc4-11e6-9d69-908ad8d6d605.png) | ![me__bright_s1_c1](https://cloud.githubusercontent.com/assets/12573621/16907562/e0a086b8-4cc4-11e6-95f2-5907d2b2dba9.png) |
| Light | ![me__light_s0_c0](https://cloud.githubusercontent.com/assets/12573621/16907570/ec8b36a8-4cc4-11e6-802e-89ae19d97195.png) | ![me__light_s1_c0](https://cloud.githubusercontent.com/assets/12573621/16907575/f188b11c-4cc4-11e6-9854-b1b0e2a4c899.png) | ![me__light_s1_c1](https://cloud.githubusercontent.com/assets/12573621/16907581/f5bba8c0-4cc4-11e6-8ffd-af34c130414c.png) |








