### PR TITLE
Fix light theme color for JSON String

### DIFF
--- a/Monokai Extended Light.JSON-tmTheme
+++ b/Monokai Extended Light.JSON-tmTheme
@@ -436,7 +436,7 @@
             "scope": "meta.structure.dictionary.json string.quoted.double.json", 
             "name": "JSON String", 
             "settings": {
-                "foreground": "#cfcfc2"
+                "foreground": "#5f5f4b"
             }
         }, 
         // CoffeeScript

--- a/Monokai Extended Light.tmTheme
+++ b/Monokai Extended Light.tmTheme
@@ -710,7 +710,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#cfcfc2</string>
+				<string>#5f5f4b</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
The gray on white in JSON files for strings is rather hard to read personally. I changed the color's brightness so text is more legible now.

Fixes #66.