### PR TITLE
'GitGutter changed' color upgraded from purple to yellow

### DIFF
--- a/Monokai Extended Bright.JSON-tmTheme
+++ b/Monokai Extended Bright.JSON-tmTheme
@@ -572,7 +572,7 @@
             "name": "GitGutter changed",
             "scope": "markup.changed.git_gutter",
             "settings": {
-                "foreground": "#967EFB"
+                "foreground": "#FC951E"
             }
         },
         {

--- a/Monokai Extended Bright.tmTheme
+++ b/Monokai Extended Bright.tmTheme
@@ -938,7 +938,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#967EFB</string>
+				<string>#FC951E</string>
 			</dict>
 		</dict>
 		<dict>

--- a/Monokai Extended Light.JSON-tmTheme
+++ b/Monokai Extended Light.JSON-tmTheme
@@ -1108,7 +1108,7 @@
             "scope": "markup.changed.git_gutter", 
             "name": "GitGutter changed", 
             "settings": {
-                "foreground": "#967EFB"
+                "foreground": "#FC951E"
             }
         }, 
         {

--- a/Monokai Extended Light.tmTheme
+++ b/Monokai Extended Light.tmTheme
@@ -1796,7 +1796,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#967EFB</string>
+				<string>#FC951E</string>
 			</dict>
 		</dict>
 		<dict>

--- a/Monokai Extended Origin.JSON-tmTheme
+++ b/Monokai Extended Origin.JSON-tmTheme
@@ -1160,7 +1160,7 @@
             "name": "GitGutter changed",
             "scope": "markup.changed.git_gutter",
             "settings": {
-                "foreground": "#967EFB"
+                "foreground": "#FC951E"
             }
         },
         {

--- a/Monokai Extended Origin.tmTheme
+++ b/Monokai Extended Origin.tmTheme
@@ -1876,7 +1876,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#967EFB</string>
+				<string>#FC951E</string>
 			</dict>
 		</dict>
 		<dict>

--- a/Monokai Extended.JSON-tmTheme
+++ b/Monokai Extended.JSON-tmTheme
@@ -1116,7 +1116,7 @@
             "name": "GitGutter changed", 
             "scope": "markup.changed.git_gutter", 
             "settings": {
-                "foreground": "#967EFB"
+                "foreground": "#FC951E"
             }
         },
         {

--- a/Monokai Extended.tmTheme
+++ b/Monokai Extended.tmTheme
@@ -1835,7 +1835,7 @@
       <key>settings</key>
       <dict>
         <key>foreground</key>
-        <string>#967EFB</string>
+        <string>#FC951E</string>
       </dict>
     </dict>
     <dict>


### PR DESCRIPTION
I believe it would be quite reasonable to change the 'GitGutter changed' color from light purple to deep yellow to achieve the natural green/yellow/red 'traffic light' visual effect.
You may remember [our previous discussion]( https://github.com/jonschlinkert/sublime-monokai-extended/pull/48). It's been a long time so I've decided to make it again. ;-)