### PR TITLE
Fix tab/space color in Light theme

### DIFF
--- a/Monokai Extended Light.tmTheme
+++ b/Monokai Extended Light.tmTheme
@@ -49,7 +49,7 @@
 				<key>foreground</key>
 				<string>#49483e</string>
 				<key>invisibles</key>
-				<string>#3b3a32</string>
+				<string>#93917b</string>
 				<key>lineHighlight</key>
 				<string>#e6e3c4</string>
 				<key>selection</key>


### PR DESCRIPTION
It was using the same color as the dark theme for "invisibles" (tabs/spaces shown when highlighting text).